### PR TITLE
fix - fix shadows breaking

### DIFF
--- a/components/about-me/profile-card-logo-component.tsx
+++ b/components/about-me/profile-card-logo-component.tsx
@@ -45,7 +45,7 @@ const ProfileCardLogoComponent = () => {
                 />
                 <div
                     // Clipboard pill
-                    className={`flex justify-center transition-all duration-400 ease-in-out ${
+                    className={`flex justify-center ${
                         isCopied ? "opacity-100" : "invisible opacity-0"
                     }`}
                 >


### PR DESCRIPTION
The shadows around the profile card breaks when animating the clipboard pill.